### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/__jay_git_prompt.fish
+++ b/__jay_git_prompt.fish
@@ -30,14 +30,14 @@ function __git_prompt_short_sha -d 'git commit short SHA'
 end
 
 function __jay_git_prompt -d 'Write out the git prompt'
-  set -l branch (git rev-parse --abbrev-ref HEAD ^/dev/null)
+  set -l branch (git rev-parse --abbrev-ref HEAD 2>/dev/null)
   if test -z $branch
     return
   end
 
   echo -n ' ['
 
-  set -l index (git status --porcelain ^/dev/null|cut -c 1-2|sort -u)
+  set -l index (git status --porcelain 2>/dev/null|cut -c 1-2|sort -u)
 
   if test -z "$index"
     set_color $fish_color_git_clean

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -14,25 +14,25 @@ function fish_prompt --description 'Write out the prompt'
 
     function __fish_repaint_user --on-variable fish_color_user --description "Event handler, repaint when fish_color_user changes"
       if status --is-interactive
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2>/dev/null
       end
     end
 
     function __fish_repaint_host --on-variable fish_color_host --description "Event handler, repaint when fish_color_host changes"
       if status --is-interactive
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2>/dev/null
       end
     end
 
     function __fish_repaint_status --on-variable fish_color_status --description "Event handler; repaint when fish_color_status changes"
       if status --is-interactive
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2>/dev/null
       end
     end
 
     function __fish_repaint_bind_mode --on-variable fish_key_bindings --description "Event handler; repaint when fish_key_bindings changes"
       if status --is-interactive
-        commandline -f repaint ^/dev/null
+        commandline -f repaint 2>/dev/null
       end
     end
 


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
